### PR TITLE
improv: add option to not cleanup devCopyDir

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -24,12 +24,17 @@ export type ViteStaticCopyOptions = {
    * @default true
    */
   flatten?: boolean
+  /**
+   * Cleanup devCopyDir
+   */
+  cleanup?: boolean
 }
 
 export type ResolvedViteStaticCopyOptions = {
   devCopyDir: string
   targets: Target[]
   flatten: boolean
+  cleanup: boolean
 }
 
 export const resolveOptions = (
@@ -37,5 +42,6 @@ export const resolveOptions = (
 ): ResolvedViteStaticCopyOptions => ({
   devCopyDir: options.devCopyDir ?? 'node_modules/.vite-static-copy',
   targets: options.targets,
-  flatten: options.flatten ?? true
+  flatten: options.flatten ?? true,
+  cleanup: options.cleanup ?? true
 })

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -7,18 +7,21 @@ import { copyAll, outputCopyLog } from './utils'
 export const servePlugin = ({
   devCopyDir,
   targets,
-  flatten
+  flatten,
+  cleanup
 }: ResolvedViteStaticCopyOptions): Plugin => {
   return {
     name: 'vite-plugin-static-copy:serve',
     apply: 'serve',
     async buildStart() {
-      // copy again
-      try {
-        await fs.rm(devCopyDir, { force: true, recursive: true })
-        // eslint-disable-next-line no-empty
-      } catch {}
-      await fs.mkdir(devCopyDir, { recursive: true })
+      if (cleanup) {
+        // copy again
+        try {
+          await fs.rm(devCopyDir, { force: true, recursive: true })
+          // eslint-disable-next-line no-empty
+        } catch {}
+        await fs.mkdir(devCopyDir, { recursive: true })
+      }
 
       const copyCount = await copyAll(devCopyDir, targets, flatten)
       outputCopyLog(copyCount)


### PR DESCRIPTION
Hi, i'm copying a wasm file over to the `/public/` folder to be able to fetch it at runtime, however the current auto rm of the devCopyDir (which rm the public folder in my case) isnt practical so i've added an option