### PR TITLE
Update: add basic file rename support

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -7,6 +7,10 @@ export type Target = {
    * destination
    */
   dest: string
+  /**
+   * rename
+   */
+  rename?: string
 }
 
 export type ViteStaticCopyOptions = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ export const collectCopyTargets = async (
 ) => {
   const copyTargets: Array<SimpleTarget> = []
 
-  for (const { src, dest } of targets) {
+  for (const { src, dest, rename = '' } of targets) {
     const matchedPaths = await fastglob(src, {
       onlyFiles: false,
       dot: true
@@ -27,7 +27,10 @@ export const collectCopyTargets = async (
           : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             dir.replace(dir.split('/')[0]!, dest)
 
-      copyTargets.push({ src: matchedPath, dest: path.join(destDir, base) })
+      copyTargets.push({
+        src: matchedPath,
+        dest: path.join(destDir, rename || base)
+      })
     }
   }
   return copyTargets


### PR DESCRIPTION
Added ability to rename files when copying. This will only work with single target files/folders.