### PR TITLE
Closing watcher on close dev server

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -89,6 +89,10 @@ export const servePlugin = ({
           outputCollectedLog(config.logger, fileMap.size)
         }, 0)
       })
+
+      httpServer?.once('close', () => {
+        watcher.close()
+      })
     }
   }
 }


### PR DESCRIPTION
There is a bug with plugin when create vite dev server manually and close it after some actions

Process in terminal should be exited but it doesn't (server was stopped but file watcher wasn't)

Current fix solves that 