### PR TITLE
Preserve timestamps on untransformed files

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -25,6 +25,11 @@ export type Target = {
    * `src` should only include files when this option is used
    */
   transform?: TransformFunc
+  /**
+   * Should timestamps on copied files be presered?
+   * Ignored for transformed files.
+   */
+  preserveTimestamps?: boolean;
 }
 
 export type ViteStaticCopyOptions = {

--- a/src/options.ts
+++ b/src/options.ts
@@ -29,7 +29,7 @@ export type Target = {
    * Should timestamps on copied files be presered?
    * Ignored for transformed files.
    */
-  preserveTimestamps?: boolean;
+  preserveTimestamps?: boolean
 }
 
 export type ViteStaticCopyOptions = {

--- a/src/options.ts
+++ b/src/options.ts
@@ -27,7 +27,10 @@ export type Target = {
   transform?: TransformFunc
   /**
    * Should timestamps on copied files be presered?
+   *
+   * When false, timestamp behavior is OS-dependent.
    * Ignored for transformed files.
+   * @default false
    */
   preserveTimestamps?: boolean
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ export type SimpleTarget = {
   src: string
   dest: string
   transform?: TransformFunc
-  preserveTimestamps?: boolean
+  preserveTimestamps: boolean
 }
 
 export const collectCopyTargets = async (
@@ -50,7 +50,7 @@ export const collectCopyTargets = async (
         src: matchedPath,
         dest: path.join(destDir, rename ?? base),
         transform,
-        preserveTimestamps
+        preserveTimestamps: preserveTimestamps ?? false
       })
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,7 @@ export type SimpleTarget = {
   src: string
   dest: string
   transform?: TransformFunc
+  preserveTimestamps?: boolean;
 }
 
 export const collectCopyTargets = async (
@@ -20,7 +21,7 @@ export const collectCopyTargets = async (
 ) => {
   const copyTargets: Array<SimpleTarget> = []
 
-  for (const { src, dest, rename, transform } of targets) {
+  for (const { src, dest, rename, transform, preserveTimestamps } of targets) {
     const matchedPaths = await fastglob(src, {
       onlyFiles: false,
       dot: true,
@@ -48,7 +49,8 @@ export const collectCopyTargets = async (
       copyTargets.push({
         src: matchedPath,
         dest: path.join(destDir, rename ?? base),
-        transform
+        transform,
+        preserveTimestamps
       })
     }
   }
@@ -72,14 +74,14 @@ export const copyAll = async (
   flatten: boolean
 ) => {
   const copyTargets = await collectCopyTargets(rootSrc, targets, flatten)
-  for (const { src, dest, transform } of copyTargets) {
+  for (const { src, dest, transform, preserveTimestamps } of copyTargets) {
     // use `path.resolve` because rootSrc/rootDest maybe absolute path
     const resolvedSrc = path.resolve(rootSrc, src)
     const resolvedDest = path.resolve(rootSrc, rootDest, dest)
     if (transform) {
       await transformCopy(transform, resolvedSrc, resolvedDest)
     } else {
-      await fs.copy(resolvedSrc, resolvedDest)
+      await fs.copy(resolvedSrc, resolvedDest, { preserveTimestamps })
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ export type SimpleTarget = {
   src: string
   dest: string
   transform?: TransformFunc
-  preserveTimestamps?: boolean;
+  preserveTimestamps?: boolean
 }
 
 export const collectCopyTargets = async (


### PR DESCRIPTION
Allowed targets to specify the `preserveTimestamps` option, as defined in `fs-extra`. The option is then passed though.

As transformed files are different from their source file, I didn't add support for preserving timestamps in that path.

I wasn't able to test this yet.

Fixes #17