### PR TITLE
fix: trim slashes from dest when flatten false; add support to ../

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,11 +63,14 @@ export const collectCopyTargets = async (
 
       // https://github.com/vladshcherbin/rollup-plugin-copy/blob/507bf5e99aa2c6d0d858821e627cb7617a1d9a6d/src/index.js#L32-L35
       const { base, dir } = path.parse(matchedPath)
+
+      const dirClean = dir.replace(/^(?:\.\.\/)+/, '')
+      const destClean = dirClean.replace(dirClean.split('/')[0], dest).replace(/^\/+|\/+$/g, '')
+
       const destDir =
         flatten || (!flatten && !dir)
           ? dest
-          : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            dir.replace(dir.split('/')[0]!, dest)
+          : destClean
 
       copyTargets.push({
         src: matchedPath,


### PR DESCRIPTION
This PR addresses https://github.com/sapphi-red/vite-plugin-static-copy/issues/46

- it removes `../` from `dir` so `dest` reliably replaces the first folder in the path on `.split('/')[0]`
- it trims slashes from the path so `destDir` doesn't end up in the root folder