### PR TITLE
feat!: improve `flatten: false` and rename to `structured: true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,4 @@ See [options.ts](https://github.com/sapphi-red/vite-plugin-static-copy/blob/main
   - Because `fast-glob` is used inside `vite`.
 - `transform` could return `null` as a way to tell the plugin not to copy the file, this is similar to the [CopyWebpackPlugin#filter](https://webpack.js.org/plugins/copy-webpack-plugin/#filter) option, but it expects `transform` to return the original content in case you want it to be copied.
 - `transform` can optionally be an object, with a `handler` property (with the same signature of the `rollup-plugin-copy` transform option) and an `encoding` property (`BufferEncoding | 'buffer'`) that will be used to read the file content so that the `handler`'s content argument will reflect the correct encoding (could be Buffer);
+- `structured: true` preserves the directory structure. It is similar to `flatten: false` in `rollup-plugin-copy`, but it covers more edge cases.

--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ See [options.ts](https://github.com/sapphi-red/vite-plugin-static-copy/blob/main
   - Because `fast-glob` is used inside `vite`.
 - `transform` could return `null` as a way to tell the plugin not to copy the file, this is similar to the [CopyWebpackPlugin#filter](https://webpack.js.org/plugins/copy-webpack-plugin/#filter) option, but it expects `transform` to return the original content in case you want it to be copied.
 - `transform` can optionally be an object, with a `handler` property (with the same signature of the `rollup-plugin-copy` transform option) and an `encoding` property (`BufferEncoding | 'buffer'`) that will be used to read the file content so that the `handler`'s content argument will reflect the correct encoding (could be Buffer);
-- `structured: true` preserves the directory structure. It is similar to `flatten: false` in `rollup-plugin-copy`, but it covers more edge cases.
+- `structured: true` preserves the directory structure. This is similar to `flatten: false` in `rollup-plugin-copy`, but it covers more edge cases.

--- a/src/build.ts
+++ b/src/build.ts
@@ -4,7 +4,7 @@ import { copyAll, outputCopyLog } from './utils'
 
 export const buildPlugin = ({
   targets,
-  flatten,
+  structured,
   silent
 }: ResolvedViteStaticCopyOptions): Plugin => {
   let config: ResolvedConfig
@@ -20,7 +20,7 @@ export const buildPlugin = ({
         config.root,
         config.build.outDir,
         targets,
-        flatten
+        structured
       )
       if (!silent) outputCopyLog(config.logger, result)
     }

--- a/src/options.ts
+++ b/src/options.ts
@@ -83,10 +83,10 @@ export type ViteStaticCopyOptions = {
    */
   targets: Target[]
   /**
-   * Remove the directory structure.
-   * @default true
+   * Preserve the directory structure.
+   * @default false
    */
-  flatten?: boolean
+  structured?: boolean
   /**
    * Suppress console output.
    * @default false
@@ -107,7 +107,7 @@ export type ViteStaticCopyOptions = {
 
 export type ResolvedViteStaticCopyOptions = {
   targets: Target[]
-  flatten: boolean
+  structured: boolean
   silent: boolean
   watch: {
     options: WatchOptions
@@ -119,7 +119,7 @@ export const resolveOptions = (
   options: ViteStaticCopyOptions
 ): ResolvedViteStaticCopyOptions => ({
   targets: options.targets,
-  flatten: options.flatten ?? true,
+  structured: options.structured ?? false,
   silent: options.silent ?? false,
   watch: {
     options: options.watch?.options ?? {},

--- a/src/options.ts
+++ b/src/options.ts
@@ -84,6 +84,8 @@ export type ViteStaticCopyOptions = {
   targets: Target[]
   /**
    * Preserve the directory structure.
+   *
+   * Similar to `flatten: false` in rollup-plugin-copy
    * @default false
    */
   structured?: boolean

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -21,7 +21,7 @@ export type FileMap = Map<string, FileMapValue[]>
 
 export const servePlugin = ({
   targets,
-  flatten,
+  structured,
   watch,
   silent
 }: ResolvedViteStaticCopyOptions): Plugin => {
@@ -34,7 +34,7 @@ export const servePlugin = ({
       const copyTargets = await collectCopyTargets(
         config.root,
         targets,
-        flatten
+        structured
       )
       updateFileMapFromTargets(copyTargets, fileMap)
     } catch (e) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,11 +71,10 @@ export const collectCopyTargets = async (
 
       // https://github.com/vladshcherbin/rollup-plugin-copy/blob/507bf5e99aa2c6d0d858821e627cb7617a1d9a6d/src/index.js#L32-L35
       const { base, dir } = path.parse(matchedPath)
-      const destDir =
-        flatten || (!flatten && !dir)
-          ? dest
-          : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            dir.replace(dir.split('/')[0]!, dest)
+
+      const dirClean = dir.replace(/^(?:\.\.\/)+/, '')
+      const destClean = `${dest}/${dirClean}`.replace(/^\/+|\/+$/g, '')
+      const destDir = flatten || (!flatten && !dir) ? dest : destClean
 
       copyTargets.push({
         src: matchedPath,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,12 +69,16 @@ export const collectCopyTargets = async (
         }
       }
 
-      // https://github.com/vladshcherbin/rollup-plugin-copy/blob/507bf5e99aa2c6d0d858821e627cb7617a1d9a6d/src/index.js#L32-L35
       const { base, dir } = path.parse(matchedPath)
 
-      const dirClean = dir.replace(/^(?:\.\.\/)+/, '')
-      const destClean = `${dest}/${dirClean}`.replace(/^\/+|\/+$/g, '')
-      const destDir = !structured || (structured && !dir) ? dest : destClean
+      let destDir: string
+      if (!structured || !dir) {
+        destDir = dest
+      } else {
+        const dirClean = dir.replace(/^(?:\.\.\/)+/, '')
+        const destClean = `${dest}/${dirClean}`.replace(/^\/+|\/+$/g, '')
+        destDir = destClean
+      }
 
       copyTargets.push({
         src: matchedPath,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,7 +38,7 @@ async function renameTarget(
 export const collectCopyTargets = async (
   root: string,
   targets: Target[],
-  flatten: boolean
+  structured: boolean
 ) => {
   const copyTargets: Array<SimpleTarget> = []
 
@@ -74,7 +74,7 @@ export const collectCopyTargets = async (
 
       const dirClean = dir.replace(/^(?:\.\.\/)+/, '')
       const destClean = `${dest}/${dirClean}`.replace(/^\/+|\/+$/g, '')
-      const destDir = flatten || (!flatten && !dir) ? dest : destClean
+      const destDir = !structured || (structured && !dir) ? dest : destClean
 
       copyTargets.push({
         src: matchedPath,
@@ -136,9 +136,9 @@ export const copyAll = async (
   rootSrc: string,
   rootDest: string,
   targets: Target[],
-  flatten: boolean
+  structured: boolean
 ) => {
-  const copyTargets = await collectCopyTargets(rootSrc, targets, flatten)
+  const copyTargets = await collectCopyTargets(rootSrc, targets, structured)
   let copiedCount = 0
 
   for (const copyTarget of copyTargets) {

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -8,8 +8,8 @@
     "build:absolute": "vite --config vite.absolute.config.ts build",
     "dev:base": "vite --config vite.base.config.ts",
     "build:base": "vite --config vite.base.config.ts build",
-    "dev:noflatten": "vite --config vite.noflatten.config.ts",
-    "build:noflatten": "vite --config vite.noflatten.config.ts build"
+    "dev:structured": "vite --config vite.structured.config.ts",
+    "build:structured": "vite --config vite.structured.config.ts build"
   },
   "devDependencies": {
     "vite": "^4.3.5",

--- a/test/fixtures/vite.noflatten.config.ts
+++ b/test/fixtures/vite.noflatten.config.ts
@@ -19,7 +19,19 @@ export default defineConfig({
         {
           src: '../fixtures2/*.txt',
           dest: 'fixture3'
-        }
+        },
+        {
+          src: 'foo.js',
+          dest: ''
+        },
+        {
+          src: 'noext',
+          dest: '.'
+        },
+        {
+          src: '../fixtures2/baz.txt',
+          dest: ''
+        },
       ],
       flatten: false
     })

--- a/test/fixtures/vite.noflatten.config.ts
+++ b/test/fixtures/vite.noflatten.config.ts
@@ -29,9 +29,9 @@ export default defineConfig({
           dest: '.'
         },
         {
-          src: '../fixtures2/baz.txt',
+          src: 'dir/bar.txt',
           dest: ''
-        },
+        }
       ],
       flatten: false
     })

--- a/test/fixtures/vite.structured.config.ts
+++ b/test/fixtures/vite.structured.config.ts
@@ -3,7 +3,7 @@ import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 export default defineConfig({
   build: {
-    outDir: './dist-noflatten'
+    outDir: './dist-structured'
   },
   plugins: [
     viteStaticCopy({
@@ -33,7 +33,7 @@ export default defineConfig({
           dest: ''
         }
       ],
-      flatten: false
+      structured: true
     })
   ]
 })

--- a/test/testcases.ts
+++ b/test/testcases.ts
@@ -158,9 +158,9 @@ export const testcases: Record<string, Testcase[]> = {
       dest: '/noext'
     },
     {
-      name: 'parent dir to empty dest',
-      src: '../fixtures2/baz.txt',
-      dest: '/fixtures2/baz.txt'
+      name: 'dir to empty dest',
+      src: './dir/bar.txt',
+      dest: '/dir/bar.txt'
     }
   ]
 }

--- a/test/testcases.ts
+++ b/test/testcases.ts
@@ -131,7 +131,7 @@ export const testcases: Record<string, Testcase[]> = {
       dest: '/base/fixture1/foo.txt'
     }
   ],
-  'vite.noflatten.config.ts': [
+  'vite.structured.config.ts': [
     {
       name: 'glob without dir',
       src: './foo.txt',

--- a/test/testcases.ts
+++ b/test/testcases.ts
@@ -140,7 +140,7 @@ export const testcases: Record<string, Testcase[]> = {
     {
       name: 'glob with dir',
       src: './dir/bar.txt',
-      dest: '/fixture2/bar.txt'
+      dest: '/fixture2/dir/bar.txt'
     },
     {
       name: 'glob with parent dir',

--- a/test/testcases.ts
+++ b/test/testcases.ts
@@ -146,6 +146,21 @@ export const testcases: Record<string, Testcase[]> = {
       name: 'glob with parent dir',
       src: '../fixtures2/baz.txt',
       dest: '/fixture3/fixtures2/baz.txt'
+    },
+    {
+      name: 'empty dest',
+      src: './foo.js',
+      dest: '/foo.js'
+    },
+    {
+      name: 'dot dest',
+      src: './noext',
+      dest: '/noext'
+    },
+    {
+      name: 'parent dir to empty dest',
+      src: '../fixtures2/baz.txt',
+      dest: '/fixtures2/baz.txt'
     }
   ]
 }


### PR DESCRIPTION
(Re-submitting  after the git history snafu on #47)

This PR addresses #46 
- remove `../` from `dir` so `dest` reliably replaces the first folder in the path on `.split('/')[0]`
- trim slashes from the path so `destDir` doesn't end up in the root folder
- update test 'glob with dir': `dest` should be expected to contain `dir` when `flatten: false`
