### PR TITLE
fix: don't try to read the content when the requested path is mapped to a directory

### DIFF
--- a/.changeset/quiet-crews-tickle.md
+++ b/.changeset/quiet-crews-tickle.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-static-copy": patch
+---
+
+don't crash when the requested path is mapped to a directory

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -262,7 +262,7 @@ export function serveStaticCopyMiddleware(
 
     try {
       const data = viaLocal(root, publicDir, fileMap, pathname)
-      if (!data) {
+      if (!data || data.stats.isDirectory()) {
         return404(res, next)
         return
       }


### PR DESCRIPTION
when the requested path is a folder
`Uncaught Error: EISDIR: illegal operation on a directory, read`