### PR TITLE
fix: use destination path for `Content-Type` header

### DIFF
--- a/.changeset/swift-dingos-compare.md
+++ b/.changeset/swift-dingos-compare.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-static-copy": patch
+---
+
+The value of `Content-Type` header was inferred and set from the src file extension. It is now infered from the dest file extension.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -124,11 +124,12 @@ function getStaticHeaders(name: string, stats: Stats) {
 }
 
 function getTransformHeaders(
-  name: string,
+  srcName: string,
+  destName: string,
   encoding: BufferEncoding | 'buffer',
   content: string | Buffer
 ) {
-  let ctype = lookup(name) || ''
+  let ctype = lookup(destName) || lookup(srcName) || ''
   if (ctype === 'text/html') ctype += ';charset=utf-8'
 
   const headers: OutgoingHttpHeaders = {
@@ -208,12 +209,14 @@ function sendStatic(
 function sendTransform(
   req: IncomingMessage,
   res: ServerResponse,
-  file: string,
+  srcName: string,
+  destName: string,
   transform: TransformOptionObject,
   transformedContent: string | Buffer
 ): void {
   const transformHeaders = getTransformHeaders(
-    file,
+    srcName,
+    destName,
     transform.encoding,
     transformedContent
   )
@@ -243,7 +246,7 @@ function setHeaders(
   // these files to be TypeScript files, and for Vite to serve them with
   // this Content-Type.
   if (/\.[tj]sx?$/.test(pathname)) {
-    res.setHeader('Content-Type', 'application/javascript')
+    res.setHeader('Content-Type', 'text/javascript')
   }
 
   if (headers) {
@@ -304,6 +307,7 @@ export function serveStaticCopyMiddleware(
           req,
           res,
           data.filepath,
+          pathname,
           transformOption,
           transformedContent
         )

--- a/test/fixtures/vite.config.ts
+++ b/test/fixtures/vite.config.ts
@@ -111,6 +111,33 @@ export default defineConfig({
           transform(content) {
             return content + '1'
           }
+        },
+        {
+          src: 'foo.js',
+          dest: 'fixture12',
+          rename: filename => {
+            return `${filename}.mp3`
+          }
+        },
+        {
+          src: 'foo.txt',
+          dest: 'fixture13',
+          transform(content) {
+            return JSON.stringify(content)
+          },
+          rename: filename => {
+            return `${filename}.json`
+          }
+        },
+        {
+          src: 'foo.js',
+          dest: 'fixture14',
+          transform(content) {
+            return `${content}+14`
+          },
+          rename: filename => {
+            return `${filename}.foo`
+          }
         }
       ]
     })

--- a/test/fixtures/vite.config.ts
+++ b/test/fixtures/vite.config.ts
@@ -121,7 +121,7 @@ export default defineConfig({
         },
         {
           src: 'foo.txt',
-          dest: 'fixture13',
+          dest: 'fixture12',
           transform(content) {
             return JSON.stringify({ value: content.trim() })
           },
@@ -131,7 +131,7 @@ export default defineConfig({
         },
         {
           src: 'foo.txt',
-          dest: 'fixture14',
+          dest: 'fixture12',
           rename: filename => {
             return `${filename}.foo`
           }

--- a/test/fixtures/vite.config.ts
+++ b/test/fixtures/vite.config.ts
@@ -123,7 +123,7 @@ export default defineConfig({
           src: 'foo.txt',
           dest: 'fixture13',
           transform(content) {
-            return JSON.stringify(content)
+            return JSON.stringify({ value: content.trim() })
           },
           rename: filename => {
             return `${filename}.json`

--- a/test/fixtures/vite.config.ts
+++ b/test/fixtures/vite.config.ts
@@ -116,7 +116,7 @@ export default defineConfig({
           src: 'foo.js',
           dest: 'fixture12',
           rename: filename => {
-            return `${filename}.mp3`
+            return `${filename}.txt`
           }
         },
         {
@@ -130,11 +130,8 @@ export default defineConfig({
           }
         },
         {
-          src: 'foo.js',
+          src: 'foo.txt',
           dest: 'fixture14',
-          transform(content) {
-            return `${content}+14`
-          },
           rename: filename => {
             return `${filename}.foo`
           }

--- a/test/testcases.ts
+++ b/test/testcases.ts
@@ -118,10 +118,10 @@ export const testcases: Record<string, Testcase[]> = {
       dest: '/fixture11/notOverwriteDir/bar.txt'
     },
     {
-      name: 'modified extension, not tranformed',
+      name: 'modified extension, known content-type',
       src: 'foo.js',
-      dest: '/fixture12/foo.mp3',
-      contentType: 'text/javascript'
+      dest: '/fixture12/foo.txt',
+      contentType: 'text/plain'
     },
     {
       name: 'modified extension, transformed, known content-type',
@@ -131,11 +131,10 @@ export const testcases: Record<string, Testcase[]> = {
       contentType: 'application/json'
     },
     {
-      name: 'modified extension, transformed, unknown content-type',
-      src: null,
+      name: 'modified extension, unknown content-type',
+      src: 'foo.txt',
       dest: '/fixture14/foo.foo',
-      transformedContent: "console.log('foo')\n+14",
-      contentType: 'text/javascript'
+      contentType: ''
     }
   ],
   'vite.absolute.config.ts': [

--- a/test/testcases.ts
+++ b/test/testcases.ts
@@ -127,7 +127,7 @@ export const testcases: Record<string, Testcase[]> = {
       name: 'modified extension, transformed, known content-type',
       src: null,
       dest: '/fixture13/foo.json',
-      transformedContent: '"foo\\n"',
+      transformedContent: '{"value":"foo"}',
       contentType: 'application/json'
     },
     {

--- a/test/testcases.ts
+++ b/test/testcases.ts
@@ -4,6 +4,7 @@ type Testcase = {
   dest: string
   transformedContent?: string
   encoding?: BufferEncoding | 'buffer'
+  contentType?: string
 }
 
 export const testcases: Record<string, Testcase[]> = {
@@ -115,6 +116,26 @@ export const testcases: Record<string, Testcase[]> = {
       name: 'overwrite=false with transform',
       src: './public/fixture11/notOverwriteDir/bar.txt',
       dest: '/fixture11/notOverwriteDir/bar.txt'
+    },
+    {
+      name: 'modified extension, not tranformed',
+      src: 'foo.js',
+      dest: '/fixture12/foo.mp3',
+      contentType: 'text/javascript'
+    },
+    {
+      name: 'modified extension, transformed, known content-type',
+      src: null,
+      dest: '/fixture13/foo.json',
+      transformedContent: '"foo\\n"',
+      contentType: 'application/json'
+    },
+    {
+      name: 'modified extension, transformed, unknown content-type',
+      src: null,
+      dest: '/fixture14/foo.foo',
+      transformedContent: "console.log('foo')\n+14",
+      contentType: 'text/javascript'
     }
   ],
   'vite.absolute.config.ts': [

--- a/test/testcases.ts
+++ b/test/testcases.ts
@@ -126,14 +126,14 @@ export const testcases: Record<string, Testcase[]> = {
     {
       name: 'modified extension, transformed, known content-type',
       src: null,
-      dest: '/fixture13/foo.json',
+      dest: '/fixture12/foo.json',
       transformedContent: '{"value":"foo"}',
       contentType: 'application/json'
     },
     {
       name: 'modified extension, unknown content-type',
       src: 'foo.txt',
-      dest: '/fixture14/foo.foo',
+      dest: '/fixture12/foo.foo',
       contentType: ''
     }
   ],

--- a/test/tests.test.ts
+++ b/test/tests.test.ts
@@ -115,13 +115,24 @@ describe('build', () => {
         })
       })
 
-      for (const { name, src, dest, transformedContent, encoding } of tests) {
+      for (const {
+        name,
+        src,
+        dest,
+        transformedContent,
+        encoding,
+        contentType
+      } of tests) {
         // eslint-disable-next-line vitest/valid-title
         test.concurrent(name, async () => {
           const expected =
             src === null ? null : await loadFileContent(src, encoding)
           const actual = await fetchContent(server, dest, encoding)
           expect(actual.content).toStrictEqual(transformedContent ?? expected)
+
+          if (contentType !== undefined) {
+            expect(actual.contentType).toStrictEqual(contentType)
+          }
         })
       }
     })

--- a/test/tests.test.ts
+++ b/test/tests.test.ts
@@ -16,22 +16,23 @@ const fetchFromServer = async (
   return res
 }
 
-const fetchTextContent = async (
+const fetchContent = async (
   server: ViteDevServer | PreviewServer,
-  path: string
+  path: string,
+  encoding?: BufferEncoding | 'buffer'
 ) => {
   const res = await fetchFromServer(server, path)
-  const content = res.status === 200 ? await res.text() : null
-  return content ? normalizeLineBreak(content) : null
-}
+  let content: string | ArrayBuffer | null = null
 
-const fetchBufferContent = async (
-  server: ViteDevServer | PreviewServer,
-  path: string
-) => {
-  const res = await fetchFromServer(server, path)
-  const content = res.status === 200 ? await res.arrayBuffer() : null
-  return content
+  if (res.status === 200) {
+    content =
+      encoding === 'buffer'
+        ? await res.arrayBuffer()
+        : normalizeLineBreak(await res.text())
+  }
+
+  const contentType = res.headers.get('content-type')
+  return { content, contentType }
 }
 
 describe('serve', () => {
@@ -47,16 +48,24 @@ describe('serve', () => {
         await server.close()
       })
 
-      for (const { name, src, dest, transformedContent, encoding } of tests) {
+      for (const {
+        name,
+        src,
+        dest,
+        transformedContent,
+        encoding,
+        contentType
+      } of tests) {
         // eslint-disable-next-line vitest/valid-title
         test.concurrent(name, async () => {
           const expected =
             src === null ? null : await loadFileContent(src, encoding)
-          const actual =
-            encoding === 'buffer'
-              ? await fetchBufferContent(server, dest)
-              : await fetchTextContent(server, dest)
-          expect(actual).toStrictEqual(transformedContent ?? expected)
+          const actual = await fetchContent(server, dest, encoding)
+          expect(actual.content).toStrictEqual(transformedContent ?? expected)
+
+          if (contentType !== undefined) {
+            expect(actual.contentType).toStrictEqual(contentType)
+          }
         })
       }
     })
@@ -111,11 +120,8 @@ describe('build', () => {
         test.concurrent(name, async () => {
           const expected =
             src === null ? null : await loadFileContent(src, encoding)
-          const actual =
-            encoding === 'buffer'
-              ? await fetchBufferContent(server, dest)
-              : await fetchTextContent(server, dest)
-          expect(actual).toStrictEqual(transformedContent ?? expected)
+          const actual = await fetchContent(server, dest, encoding)
+          expect(actual.content).toStrictEqual(transformedContent ?? expected)
         })
       }
     })


### PR DESCRIPTION
Uses the target path to determine content-type instead of the source path. The content-type sent from a dev server should match that sent from a preview-mode server.

This PR also updates the content-type value for script files to `text/javascript`, to match that used by mrmime: https://github.com/lukeed/mrmime/issues/8

Small update/refactor to the test code.

Fixes #119.