### PR TITLE
feat: throw an error when no file was found

### DIFF
--- a/.changeset/rotten-seals-invite.md
+++ b/.changeset/rotten-seals-invite.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-static-copy': major
+---
+
+feat: throw an error when does not find file

--- a/src/build.ts
+++ b/src/build.ts
@@ -29,7 +29,8 @@ export const buildPlugin = ({
         config.root,
         config.build.outDir,
         targets,
-        structured
+        structured,
+        silent
       )
       if (!silent) outputCopyLog(config.logger, result)
     }

--- a/src/options.ts
+++ b/src/options.ts
@@ -90,7 +90,7 @@ export type ViteStaticCopyOptions = {
    */
   structured?: boolean
   /**
-   * Suppress console output.
+   * Suppress console output and ignore validation errors.
    * @default false
    */
   silent?: boolean

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -39,8 +39,9 @@ export const servePlugin = ({
       )
       updateFileMapFromTargets(copyTargets, fileMap)
     } catch (e) {
-      !silent &&
+      if (!silent) {
         config.logger.error(formatConsole(pc.red((e as Error).toString())))
+      }
     }
   }
   const collectFileMapDebounce = debounce(100, async () => {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -34,11 +34,13 @@ export const servePlugin = ({
       const copyTargets = await collectCopyTargets(
         config.root,
         targets,
-        structured
+        structured,
+        silent
       )
       updateFileMapFromTargets(copyTargets, fileMap)
     } catch (e) {
-      config.logger.error(formatConsole(pc.red((e as Error).toString())))
+      !silent &&
+        config.logger.error(formatConsole(pc.red((e as Error).toString())))
     }
   }
   const collectFileMapDebounce = debounce(100, async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,7 +38,8 @@ async function renameTarget(
 export const collectCopyTargets = async (
   root: string,
   targets: Target[],
-  structured: boolean
+  structured: boolean,
+  silent = false
 ) => {
   const copyTargets: SimpleTarget[] = []
 
@@ -59,6 +60,9 @@ export const collectCopyTargets = async (
       cwd: root
     })
 
+    if (matchedPaths.length === 0 && !silent) {
+      throw new Error(`No file was found to copy on ${src} src.`)
+    }
     for (const matchedPath of matchedPaths) {
       const relativeMatchedPath = path.isAbsolute(matchedPath)
         ? path.relative(root, matchedPath)
@@ -145,9 +149,15 @@ export const copyAll = async (
   rootSrc: string,
   rootDest: string,
   targets: Target[],
-  structured: boolean
+  structured: boolean,
+  silent = false
 ) => {
-  const copyTargets = await collectCopyTargets(rootSrc, targets, structured)
+  const copyTargets = await collectCopyTargets(
+    rootSrc,
+    targets,
+    structured,
+    silent
+  )
   let copiedCount = 0
 
   for (const copyTarget of copyTargets) {
@@ -244,8 +254,6 @@ export const outputCopyLog = (
     const skippedMessage =
       skipped > 0 ? ` ${pc.gray(`(Skipped ${skipped} items.)`)}` : ''
     logger.info(formatConsole(`${copiedMessage}${skippedMessage}`))
-  } else {
-    logger.warn(formatConsole(pc.yellow('No items to copy.')))
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,7 @@ export const collectCopyTargets = async (
   root: string,
   targets: Target[],
   structured: boolean,
-  silent = false
+  silent: boolean
 ) => {
   const copyTargets: SimpleTarget[] = []
 
@@ -150,7 +150,7 @@ export const copyAll = async (
   rootDest: string,
   targets: Target[],
   structured: boolean,
-  silent = false
+  silent: boolean
 ) => {
   const copyTargets = await collectCopyTargets(
     rootSrc,

--- a/test/fixtures/vite.error-silent.config.ts
+++ b/test/fixtures/vite.error-silent.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
+
+export default defineConfig({
+  plugins: [
+    viteStaticCopy({
+      targets: [
+        {
+          src: 'does-not-exist.txt',
+          dest: 'does-not-exist'
+        }
+      ],
+      silent: true
+    })
+  ]
+})

--- a/test/fixtures/vite.error.config.ts
+++ b/test/fixtures/vite.error.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
+
+export default defineConfig({
+  plugins: [
+    viteStaticCopy({
+      targets: [
+        {
+          src: 'does-not-exist.txt',
+          dest: 'does-not-exist'
+        }
+      ]
+    })
+  ]
+})

--- a/test/tests.test.ts
+++ b/test/tests.test.ts
@@ -145,9 +145,9 @@ describe('build', () => {
       } catch (error: unknown) {
         result = (error as Error).message
       }
-      expect(
-        result.includes('No file was found to copy on does-not-exist.txt src.')
-      ).toBeTruthy()
+      expect(result).toContain(
+        'No file was found to copy on does-not-exist.txt src.'
+      )
     })
 
     test('should not throw error when it does not find the file on given src as silent=true', async () => {

--- a/test/tests.test.ts
+++ b/test/tests.test.ts
@@ -137,4 +137,27 @@ describe('build', () => {
       }
     })
   }
+  describe('on error', () => {
+    test('should throw error when it does not find the file on given src', async () => {
+      let result = ''
+      try {
+        await build(getConfig('vite.error.config.ts'))
+      } catch (error: unknown) {
+        result = (error as Error).message
+      }
+      expect(
+        result.includes('No file was found to copy on does-not-exist.txt src.')
+      ).toBeTruthy()
+    })
+
+    test('should not throw error when it does not find the file on given src as silent=true', async () => {
+      let result = ''
+      try {
+        await build(getConfig('vite.error-silent.config.ts'))
+      } catch (error: unknown) {
+        result = (error as Error).message
+      }
+      expect(result).toBe('')
+    })
+  })
 })


### PR DESCRIPTION
[reasons here](https://github.com/sapphi-red/vite-plugin-static-copy/issues/126)

# important points: 
- I tried to follow the same pattern error (which is treated directly on the function, that's why I passed `silent` to the `copyAll`). Another alternative I thought was to return an array of failed results and use `outputCopyLog` to show them, then I would not need to pass the `silent` flag.
- I used `silent` as it looks for this purpose. I don't think make sense to create another flag

# Evidence:

## build

silent=false
![silente=false](https://github.com/user-attachments/assets/2cbdff71-c262-4beb-a85c-505ab20620fc)

silent=true
![on-silent=true](https://github.com/user-attachments/assets/62011585-82d9-4da1-9746-daf69e690696)


## server

silent=false
![server-silente=false](https://github.com/user-attachments/assets/01e06f54-5606-4098-b671-01f2d1516057)

silent=true (the server keeps running, but there is a logger.error)
![server-error](https://github.com/user-attachments/assets/b10c51c8-e000-40cf-88e5-b2759076fb89)
