### PR TITLE
feat: add `hook` option to control when plugin is ran

### DIFF
--- a/.changeset/curvy-cougars-wonder.md
+++ b/.changeset/curvy-cougars-wonder.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-static-copy': minor
+---
+
+Allows user to optionally configure when the plugin is ran by passing in a Rollup hook name

--- a/src/build.ts
+++ b/src/build.ts
@@ -5,7 +5,8 @@ import { copyAll, outputCopyLog } from './utils'
 export const buildPlugin = ({
   targets,
   structured,
-  silent
+  silent,
+  hook
 }: ResolvedViteStaticCopyOptions): Plugin => {
   let config: ResolvedConfig
   let output = false
@@ -20,7 +21,7 @@ export const buildPlugin = ({
       // reset for watch mode
       output = false
     },
-    async writeBundle() {
+    async [hook]() {
       // run copy only once even if multiple bundles are generated
       if (output) return
       output = true

--- a/src/options.ts
+++ b/src/options.ts
@@ -105,6 +105,11 @@ export type ViteStaticCopyOptions = {
      */
     reloadPageOnChange?: boolean
   }
+  /**
+   * Rollup hook the plugin should use during build.
+   * @default 'writeBundle'
+   */
+  hook?: string
 }
 
 export type ResolvedViteStaticCopyOptions = {
@@ -115,6 +120,7 @@ export type ResolvedViteStaticCopyOptions = {
     options: WatchOptions
     reloadPageOnChange: boolean
   }
+  hook: string
 }
 
 export const resolveOptions = (
@@ -126,5 +132,6 @@ export const resolveOptions = (
   watch: {
     options: options.watch?.options ?? {},
     reloadPageOnChange: options.watch?.reloadPageOnChange ?? false
-  }
+  },
+  hook: options.hook ?? 'writeBundle'
 })

--- a/test/fixtures/vite.hook.config.ts
+++ b/test/fixtures/vite.hook.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, normalizePath } from 'vite'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import url from 'node:url'
+
+const _dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  plugins: [
+    viteStaticCopy({
+      targets: [
+        {
+          src: 'foo.txt',
+          dest: 'hook1'
+        }
+      ],
+      hook: 'generateBundle'
+    }),
+    testHookPlugin()
+  ]
+})
+
+function testHookPlugin() {
+  return {
+    name: 'test-hook-plugin',
+    async writeBundle() {
+      const filePath = normalizePath(
+        path.resolve(_dirname, 'dist', 'hook1', 'foo.txt')
+      )
+      await fs.access(filePath)
+    }
+  }
+}

--- a/test/fixtures/vite.hook.config.ts
+++ b/test/fixtures/vite.hook.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, normalizePath } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
-import { promises as fs } from 'node:fs'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 import url from 'node:url'
 

--- a/test/tests.test.ts
+++ b/test/tests.test.ts
@@ -137,6 +137,17 @@ describe('build', () => {
       }
     })
   }
+
+  test('should support hook option', async () => {
+    let result = ''
+    try {
+      await build(getConfig('vite.hook.config.ts'))
+    } catch (error: unknown) {
+      result = (error as Error).message
+    }
+    expect(result).toBe('')
+  })
+
   describe('on error', () => {
     test('should throw error when it does not find the file on given src', async () => {
       let result = ''


### PR DESCRIPTION
Fixes #132

Not very familiar with this repo, let me know if you'd like to see things done any other way, formatted differently, etc.! Happy to make adjustments.

For a test, I basically reproduced the situation I mentioned in the issue; another plugin in `writeBundle` will attempt to read the file, so if we cannot access it, throw and fail the test.