### PR TITLE
Added transform support for zlib compressed output

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -21,11 +21,13 @@ export type TransformFunc<T extends string | Buffer> = (
 export type TransformOptionObject =
   | {
       encoding: Exclude<BufferEncoding, 'binary'>
-      handler: TransformFunc<string>
+      handler: TransformFunc<string>,
+      options?: Record<string, any>
     }
   | {
       encoding: 'buffer'
       handler: TransformFunc<Buffer>
+      options?: Record<string, any>
     }
 
 export type TransformOption = TransformFunc<string> | TransformOptionObject


### PR DESCRIPTION
Great library, but wanted easy way to add compression of files copied over, ex.
viteStaticCopy({
            targets: [{ src: 'assets/wifi-*.svg', dest: 'assets', transform: { encoding: 'gzip' } }]
          }),

This little modification gives that option by specifying transform.encoding = [gzip | brotliCompress | deflate]
