### PR TITLE
Enhanced transform functionality to include compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ export default {
       targets: [
         {
           src: 'images/*.svg',
-          dest: 'assets', 
+          dest: 'assets',
           transform: { compress: 'gzip' }
         }
       ]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ So the file will be copied to `dist/wasm-files/example.wasm`.
 >
 > See [`fast-glob` documentation about this](https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows) for more details.
 
+## Usage (Compressing Content)
+
+Add `viteStaticCopy` plugin to `vite.config.js` / `vite.config.ts`. Destination files will now be compressed with selected algorithm (gzip, brotli, deflate) and have corresponding extension.
+
+```js
+// vite.config.js / vite.config.ts
+import { viteStaticCopy } from 'vite-plugin-static-copy'
+
+export default {
+  plugins: [
+    viteStaticCopy({
+      targets: [
+        {
+          src: 'images/*.svg',
+          dest: 'assets', 
+          transform: { compress: 'gzip' }
+        }
+      ]
+    })
+  ]
+}
+```
+
 ### Options
 
 See [options.ts](https://github.com/sapphi-red/vite-plugin-static-copy/blob/main/src/options.ts).

--- a/src/options.ts
+++ b/src/options.ts
@@ -27,6 +27,7 @@ export type TransformOptionObject =
   | {
       encoding: 'buffer'
       handler: TransformFunc<Buffer>
+      compress?: 'gzip' | 'brotli' | 'deflate'
     }
 
 export type TransformOption = TransformFunc<string> | TransformOptionObject

--- a/src/options.ts
+++ b/src/options.ts
@@ -22,6 +22,7 @@ export type TransformOptionObject =
   | {
       encoding: Exclude<BufferEncoding, 'binary'>
       handler: TransformFunc<string>
+      compress?: 'gzip' | 'brotli' | 'deflate'
     }
   | {
       encoding: 'buffer'

--- a/src/options.ts
+++ b/src/options.ts
@@ -22,12 +22,12 @@ export type TransformOptionObject =
   | {
       encoding: Exclude<BufferEncoding, 'binary'>
       handler: TransformFunc<string>
-      compress?: 'gzip' | 'brotli' | 'deflate'
+      compress?: 'gzip' | 'brotliCompress' | 'deflate'
     }
   | {
       encoding: 'buffer'
       handler: TransformFunc<Buffer>
-      compress?: 'gzip' | 'brotli' | 'deflate'
+      compress?: 'gzip' | 'brotliCompress' | 'deflate'
     }
 
 export type TransformOption = TransformFunc<string> | TransformOptionObject

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,24 +109,34 @@ async function getCompressedContent(
   file: string,
   transform: TransformOptionObject
 ) {
-  let destExt;
-  switch(transform.compress){
-    case 'brotliCompress': destExt = '.br'; break;
-    case 'deflate': destExt = '.zz'; break;
-    case 'gzip': destExt = '.gz'; break;
-    default: destExt = ''; break;
+  let destExt
+  switch (transform.compress) {
+    case 'brotliCompress':
+      destExt = '.br'
+      break
+    case 'deflate':
+      destExt = '.zz'
+      break
+    case 'gzip':
+      destExt = '.gz'
+      break
+    default:
+      destExt = ''
+      break
   }
   //unknown encoding, return empty compressed
-  if(destExt == ""){
-    return { destExt, transformedContent: null };
+  if (destExt == '') {
+    return { destExt, transformedContent: null }
   }
 
   const content = await fs.readFile(file)
 
   const data = await new Promise((resolve, reject) => {
     zlib[transform.compress](content, {}, (err, result) => {
-      if (err) reject(err); else resolve(result);
-    })});
+      if (err) reject(err)
+      else resolve(result)
+    })
+  })
 
   return { destExt, data }
 }
@@ -165,10 +175,12 @@ async function transformCopy(
 
   const compressed = await getCompressedContent(src, transform)
   // if this worked, adjust dest and use, else retry with getTransformedContent()
-  if( compressed.destExt ){
-    dest += compressed.destExt;
+  if (compressed.destExt) {
+    dest += compressed.destExt
   }
-  const transformedContent = compressed.data ? compressed.data : await getTransformedContent(src, transform)
+  const transformedContent = compressed.data
+    ? compressed.data
+    : await getTransformedContent(src, transform)
   if (transformedContent === null) {
     return { copied: false }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,7 @@ import type {
 import type { Logger } from 'vite'
 import type { FileMap } from './serve'
 import { createHash } from 'node:crypto'
+import zlib from 'zlib';
 
 export type SimpleTarget = {
   src: string
@@ -126,17 +127,17 @@ async function getCompressedContent(
   }
   //unknown encoding, return empty compressed
   if (destExt == '') {
-    return { destExt, transformedContent: null }
+    return { destExt, data: null }
   }
 
   const content = await fs.readFile(file)
 
-  const data = await new Promise((resolve, reject) => {
-    zlib[transform.compress](content, {}, (err, result) => {
-      if (err) reject(err)
-      else resolve(result)
-    })
-  })
+  const data = await new Promise<Buffer>((resolve, reject) => {
+    zlib[transform.compress](content, (err: Error | null, result: Buffer) => {
+      if (err) reject(err);
+      else resolve(result);
+    });
+  });
 
   return { destExt, data }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,10 +134,10 @@ async function getCompressedContent(
 
   const data = await new Promise<Buffer>((resolve, reject) => {
     zlib[transform.compress](content, (err: Error | null, result: Buffer) => {
-      if (err) reject(err);
-      else resolve(result);
-    });
-  });
+      if (err) reject(err)
+      else resolve(result)
+    })
+  })
 
   return { destExt, data }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -133,10 +133,13 @@ async function getCompressedContent(
   const content = await fs.readFile(file)
 
   const data = await new Promise<Buffer>((resolve, reject) => {
-    zlib[transform.compress](content, (err: Error | null, result: Buffer) => {
-      if (err) reject(err)
-      else resolve(result)
-    })
+    zlib[transform.compress || 'gzip'](
+      content,
+      (err: Error | null, result: Buffer) => {
+        if (err) reject(err)
+        else resolve(result)
+      }
+    )
   })
 
   return { destExt, data }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -177,13 +177,13 @@ async function transformCopy(
     }
   }
 
-  const compressed = await getCompressedContent(src, transform)
+  const { destExt, data } = await getCompressedContent(src, transform)
   // if this worked, adjust dest and use, else retry with getTransformedContent()
-  if (compressed.destExt) {
-    dest += compressed.destExt
+  if (destExt) {
+    dest += destExt
   }
-  const transformedContent = compressed.data
-    ? compressed.data
+  const transformedContent = destExt
+    ? data
     : await getTransformedContent(src, transform)
   if (transformedContent === null) {
     return { copied: false }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ import type {
 import type { Logger } from 'vite'
 import type { FileMap } from './serve'
 import { createHash } from 'node:crypto'
-import zlib from 'zlib';
+import zlib from 'zlib'
 
 export type SimpleTarget = {
   src: string


### PR DESCRIPTION
Added 'compress' method to transform, and uses zlib to compress target files (with  (zlib: gzip, brotli, deflate).

Usage example:
```
viteStaticCopy({
            targets: [ 
              { src: 'images/*.svg', dest: 'assets', transform: { compress: 'gzip' }
               }]
          }),
```