### PR TITLE
perf: copy files concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "chokidar": "^3.5.3",
     "fast-glob": "^3.2.11",
     "fs-extra": "^11.1.0",
+    "p-map": "^7.0.3",
     "picocolors": "^1.0.0"
   },
   "packageManager": "pnpm@9.12.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       fs-extra:
         specifier: ^11.1.0
         version: 11.2.0
+      p-map:
+        specifier: ^7.0.3
+        version: 7.0.3
       picocolors:
         specifier: ^1.0.0
         version: 1.1.0
@@ -1434,6 +1437,10 @@ packages:
   p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
+
+  p-map@7.0.3:
+    resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
+    engines: {node: '>=18'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -3306,6 +3313,8 @@ snapshots:
       p-limit: 3.1.0
 
   p-map@2.1.0: {}
+
+  p-map@7.0.3: {}
 
   p-try@2.2.0: {}
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest'
+import { groupTargetsByDirectoryTree } from './utils'
+import path from 'node:path'
+
+describe('groupTargetsByDirectoryTree', () => {
+  const defineCase = (input: string[], expected: string[][]) => ({
+    name: input.join(', '),
+    input: input.map(s => ({ resolvedDest: path.resolve(s) })),
+    expected: expected.map(s =>
+      s.map(s => expect.objectContaining({ resolvedDest: path.resolve(s) }))
+    )
+  })
+
+  const cases = [
+    defineCase(['a/b/c'], [['a/b/c']]),
+    defineCase(['a/b/c', 'b/c'], [['a/b/c'], ['b/c']]),
+    defineCase(['a', 'a/b/c'], [['a', 'a/b/c']]),
+    defineCase(['a/b', 'a/b/c'], [['a/b', 'a/b/c']]),
+    defineCase(['a/b/c', 'a/b'], [['a/b/c', 'a/b']]),
+    defineCase(['a', 'a/b/d'], [['a', 'a/b/d']])
+  ] satisfies Array<{
+    name: string
+    input: Array<{ resolvedDest: string }>
+    expected: Array<{ resolvedDest: string }>[]
+  }>
+
+  for (const { name, input, expected } of cases) {
+    test(`groupTargetsByDirectoryTree(${name})`, () => {
+      expect(groupTargetsByDirectoryTree(input)).toStrictEqual(expected)
+    })
+  }
+})

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -18,11 +18,11 @@ describe('groupTargetsByDirectoryTree', () => {
     defineCase(['a/b', 'a/b/c'], [['a/b', 'a/b/c']]),
     defineCase(['a/b/c', 'a/b'], [['a/b/c', 'a/b']]),
     defineCase(['a', 'a/b/d'], [['a', 'a/b/d']])
-  ] satisfies Array<{
+  ] satisfies {
     name: string
-    input: Array<{ resolvedDest: string }>
-    expected: Array<{ resolvedDest: string }>[]
-  }>
+    input: { resolvedDest: string }[]
+    expected: { resolvedDest: string }[][]
+  }[]
 
   for (const { name, input, expected } of cases) {
     test(`groupTargetsByDirectoryTree(${name})`, () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,7 +48,7 @@ export const groupTargetsByDirectoryTree = <T extends { resolvedDest: string }>(
           : -1
     )
 
-  const groups: Record<string, Array<T & { order: number }>> = {}
+  const groups: Record<string, (T & { order: number })[]> = {}
   for (const target of targetsWithOrder) {
     const { resolvedDest } = target
     const parent = Object.keys(groups).find(key =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,8 @@ import type { FileMap } from './serve'
 import { createHash } from 'node:crypto'
 import pMap from 'p-map'
 
+const CONCURRENCY = 5
+
 export type SimpleTarget = {
   src: string
   dest: string
@@ -42,68 +44,77 @@ export const collectCopyTargets = async (
   structured: boolean,
   silent: boolean
 ) => {
-  const copyTargets: SimpleTarget[] = []
-
-  for (const target of targets) {
-    const {
-      src,
-      dest,
-      rename,
-      transform,
-      preserveTimestamps,
-      dereference,
-      overwrite
-    } = target
-
-    const matchedPaths = await fastglob(src, {
-      onlyFiles: false,
-      dot: true,
-      cwd: root
-    })
-
-    if (matchedPaths.length === 0 && !silent) {
-      throw new Error(`No file was found to copy on ${src} src.`)
-    }
-    for (const matchedPath of matchedPaths) {
-      const relativeMatchedPath = path.isAbsolute(matchedPath)
-        ? path.relative(root, matchedPath)
-        : matchedPath
-      const absoluteMatchedPath = path.resolve(root, matchedPath)
-
-      if (transform) {
-        const srcStat = await fs.stat(absoluteMatchedPath)
-        if (!srcStat.isFile()) {
-          throw new Error(
-            `"transform" option only supports a file: '${relativeMatchedPath}' is not a file`
-          )
-        }
-      }
-
-      const { base, dir } = path.parse(relativeMatchedPath)
-
-      let destDir: string
-      if (!structured || !dir) {
-        destDir = dest
-      } else {
-        const dirClean = dir.replace(/^(?:\.\.\/)+/, '')
-        const destClean = `${dest}/${dirClean}`.replace(/^\/+|\/+$/g, '')
-        destDir = destClean
-      }
-
-      copyTargets.push({
-        src: relativeMatchedPath,
-        dest: path.join(
-          destDir,
-          rename ? await renameTarget(base, rename, absoluteMatchedPath) : base
-        ),
+  const copyTargets: SimpleTarget[][] = await pMap(
+    targets,
+    async target => {
+      const {
+        src,
+        dest,
+        rename,
         transform,
-        preserveTimestamps: preserveTimestamps ?? false,
-        dereference: dereference ?? true,
-        overwrite: overwrite ?? true
+        preserveTimestamps,
+        dereference,
+        overwrite
+      } = target
+
+      const matchedPaths = await fastglob(src, {
+        onlyFiles: false,
+        dot: true,
+        cwd: root
       })
-    }
-  }
-  return copyTargets
+
+      if (matchedPaths.length === 0 && !silent) {
+        throw new Error(`No file was found to copy on ${src} src.`)
+      }
+      return pMap(
+        matchedPaths,
+        async matchedPath => {
+          const relativeMatchedPath = path.isAbsolute(matchedPath)
+            ? path.relative(root, matchedPath)
+            : matchedPath
+          const absoluteMatchedPath = path.resolve(root, matchedPath)
+
+          if (transform) {
+            const srcStat = await fs.stat(absoluteMatchedPath)
+            if (!srcStat.isFile()) {
+              throw new Error(
+                `"transform" option only supports a file: '${relativeMatchedPath}' is not a file`
+              )
+            }
+          }
+
+          const { base, dir } = path.parse(relativeMatchedPath)
+
+          let destDir: string
+          if (!structured || !dir) {
+            destDir = dest
+          } else {
+            const dirClean = dir.replace(/^(?:\.\.\/)+/, '')
+            const destClean = `${dest}/${dirClean}`.replace(/^\/+|\/+$/g, '')
+            destDir = destClean
+          }
+
+          return {
+            src: relativeMatchedPath,
+            dest: path.join(
+              destDir,
+              rename
+                ? await renameTarget(base, rename, absoluteMatchedPath)
+                : base
+            ),
+            transform,
+            preserveTimestamps: preserveTimestamps ?? false,
+            dereference: dereference ?? true,
+            overwrite: overwrite ?? true
+          }
+        },
+        { concurrency: CONCURRENCY }
+      )
+    },
+    { concurrency: CONCURRENCY }
+  )
+
+  return copyTargets.flat()
 }
 
 export async function getTransformedContent(
@@ -214,7 +225,7 @@ export const copyAll = async (
         }
       }
     },
-    { concurrency: 5 }
+    { concurrency: CONCURRENCY }
   )
 
   return { targets: copyTargets.length, copied: copiedCount }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,9 +56,18 @@ export const groupTargetsByDirectoryTree = <T extends { resolvedDest: string }>(
     )
     if (parent) {
       groups[parent]!.push(target)
-    } else {
-      groups[resolvedDest] = [target]
+      continue
     }
+    const child = Object.keys(groups).find(key =>
+      isSubdirectoryOrEqual(resolvedDest, key)
+    )
+    if (child) {
+      groups[resolvedDest] = [target, ...groups[child]!]
+      delete groups[child]
+      continue
+    }
+
+    groups[resolvedDest] = [target]
   }
   const groupList = Object.values(groups)
   for (const g of groupList) {


### PR DESCRIPTION
This PR solves #145 by introducing concurrency with `p-map` library (new dependency)

to address race conditon issue in #14 for which `Promise.all` was switched to `for await` loop, targets are grouped by destination, and concurrency will base on group; and inside each group, file copies are still looped

perf improvements on ~2000 small files (vite build time before/after): 72s/22s