### PR TITLE
fix: inject middleware correctly when there's multiple plugin instances

### DIFF
--- a/.changeset/brave-phones-read.md
+++ b/.changeset/brave-phones-read.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-static-copy': patch
+---
+
+fix a bug that the content was not sent when multiple vite-plugin-static-copy instance was used

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -123,14 +123,14 @@ export const servePlugin = ({
       return () => {
         // insert serveStaticCopyMiddleware before viteServePublicMiddleware
         // if viteServePublicMiddleware didn't exist use transformMiddleware instead
-        middlewares.use(serveStaticCopyMiddleware(config, fileMap))
+        const middleware = serveStaticCopyMiddleware(config, fileMap)
+        middlewares.use(middleware)
         const targetMiddlewareIndex = findMiddlewareIndex(middlewares.stack, [
           'viteServePublicMiddleware',
           'viteTransformMiddleware',
         ])
-        const serveStaticCopyMiddlewareIndex = findMiddlewareIndex(
-          middlewares.stack,
-          'viteServeStaticCopyMiddleware',
+        const serveStaticCopyMiddlewareIndex = middlewares.stack.findIndex(
+          item => item.handle === middleware,
         )
 
         const serveStaticCopyMiddlewareItem = middlewares.stack.splice(

--- a/test/fixtures/vite.config.ts
+++ b/test/fixtures/vite.config.ts
@@ -148,5 +148,13 @@ export default defineConfig({
         { src: 'eexist/*', dest: 'Eexist' },
       ],
     }),
+    viteStaticCopy({
+      targets: [
+        {
+          src: 'foo.txt',
+          dest: 'fixture1-1',
+        },
+      ]
+    }),
   ],
 })

--- a/test/testcases.ts
+++ b/test/testcases.ts
@@ -151,6 +151,11 @@ export const testcases: Record<string, Testcase[]> = {
       src: './eexist/b/1.txt',
       dest: '/eexist/b/1.txt',
     },
+    {
+      name: 'multiple plugin instance',
+      src: './foo.txt',
+      dest: '/fixture1-1/foo.txt',
+    },
   ],
   'vite.absolute.config.ts': [
     {


### PR DESCRIPTION
Reported at https://github.com/sapphi-red/vite-plugin-static-copy/discussions/184#discussioncomment-13732902