### PR TITLE
feat: add `rename.stripBase` option

### DIFF
--- a/.changeset/large-tables-tickle.md
+++ b/.changeset/large-tables-tickle.md
@@ -1,0 +1,7 @@
+---
+'vite-plugin-static-copy': minor
+---
+
+Add `{ stripBase: number }` object form to the `rename` option. This strips the given number of leading directory segments from the matched path, avoiding the need for manual `../` traversals in a rename function.
+
+This is useful when copying files from deep paths like `node_modules/my-lib/dist/**/*` with `structured: true`, where the full directory structure would otherwise be preserved in the output. Instead of writing a rename function that manually returns `../` traversals to flatten unwanted nesting, you can use `rename: { stripBase: N }` to declaratively strip the leading segments.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { buildPlugin } from './build'
 export type { ViteStaticCopyOptions }
 export type {
   RenameFunc,
+  RenameObject,
   TransformFunc,
   TransformOption,
   Target,

--- a/src/options.ts
+++ b/src/options.ts
@@ -8,6 +8,8 @@ export type RenameFunc = (
   fullPath: string,
 ) => MaybePromise<string>
 
+export type RenameObject = { stripBase: number }
+
 /**
  * @param content content of file
  * @param filename absolute path to the file
@@ -46,16 +48,22 @@ export type Target = {
    *
    * When a string is provided, the matched file is renamed to that string.
    *
+   * When an object `{ stripBase: number }` is provided, the given number of
+   * leading directory segments from the matched path are stripped from the
+   * structured destination. For example, with `structured: true` and a matched
+   * path of `dir/deep/bar.txt`, `rename: { stripBase: 1 }` removes `dir/` so
+   * the file is written to `dest/deep/bar.txt` instead of
+   * `dest/dir/deep/bar.txt`.
+   *
    * When a function is provided, it receives `(fileName, fileExtension, fullPath)`
    * and should return the new file name.
-   *
    * The returned value is joined with the resolved `dest` directory using
    * `path.join`, so it can include path segments (e.g. `subdir/file.txt`) or
    * `../` traversals to restructure the output. For example, with
    * `structured: true`, returning `../${name}.${ext}` strips one directory
    * level that `structured` would otherwise add.
    */
-  rename?: string | RenameFunc
+  rename?: string | RenameObject | RenameFunc
   /**
    * transform
    *

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises'
 import pc from 'picocolors'
 import type {
   RenameFunc,
+  RenameObject,
   Target,
   TransformOption,
   TransformOptionObject,
@@ -185,13 +186,21 @@ export const groupTargetsByDirectoryTree = <T extends { resolvedDest: string }>(
 
 async function renameTarget(
   target: string,
-  rename: string | RenameFunc,
+  rename: string | RenameObject | RenameFunc,
   src: string,
+  dir: string,
 ): Promise<string> {
   const parsedPath = path.parse(target)
 
   if (typeof rename === 'string') {
     return rename
+  }
+
+  if (typeof rename === 'object' && 'stripBase' in rename) {
+    const dirSegments = dir ? dir.split('/') : []
+    const goUp = '../'.repeat(dirSegments.length)
+    const remaining = dirSegments.slice(rename.stripBase).join('/')
+    return remaining ? `${goUp}${remaining}/${target}` : `${goUp}${target}`
   }
 
   return rename(parsedPath.name, parsedPath.ext.replace('.', ''), src)
@@ -256,7 +265,9 @@ export const collectCopyTargets = async (
         src: relativeMatchedPath,
         dest: path.join(
           destDir,
-          rename ? await renameTarget(base, rename, absoluteMatchedPath) : base,
+          rename
+            ? await renameTarget(base, rename, absoluteMatchedPath, dir)
+            : base,
         ),
         transform,
         preserveTimestamps: preserveTimestamps ?? false,

--- a/test/fixtures/vite.structured.config.ts
+++ b/test/fixtures/vite.structured.config.ts
@@ -56,6 +56,16 @@ export default defineConfig({
             return `../../dir/${_name}2.${_ext}`
           },
         },
+        {
+          src: 'dir/bar.txt',
+          dest: 'fixture6',
+          rename: { stripBase: 1 },
+        },
+        {
+          src: 'dir/deep/bar.txt',
+          dest: 'fixture6',
+          rename: { stripBase: 1 },
+        },
       ],
       structured: true,
     }),

--- a/test/testcases.ts
+++ b/test/testcases.ts
@@ -222,6 +222,16 @@ export const testcases: Record<string, Testcase[]> = {
       src: './dir/deep/bar.txt',
       dest: '/fixture5/dir/bar2.txt',
     },
+    {
+      name: 'stripBase on single dir',
+      src: './dir/bar.txt',
+      dest: '/fixture6/bar.txt',
+    },
+    {
+      name: 'stripBase on deeper nesting',
+      src: './dir/deep/bar.txt',
+      dest: '/fixture6/deep/bar.txt',
+    },
   ],
   'vite.envs.config.ts': [
     {


### PR DESCRIPTION
Add `rename.stripBase` option so that it's easier to handle cases described in https://github.com/sapphi-red/vite-plugin-static-copy/issues/125