### PR TITLE
refactor!: upgrade chokidar to v5

### DIFF
--- a/.changeset/upgrade-chokidar-5.md
+++ b/.changeset/upgrade-chokidar-5.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-static-copy': major
+---
+
+Upgrade chokidar to v5. The `watch.options` type is now `ChokidarOptions` (was `WatchOptions`), and options removed upstream (e.g. `disableGlobbing`, `useFsEvents`) are no longer accepted.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@polka/url": "^1.0.0-next.29",
     "@types/eslint-config-prettier": "^6.11.3",
     "@types/node": "^22.19.17",
+    "@types/picomatch": "^4.0.2",
     "@types/throttle-debounce": "^5.0.2",
     "@vitest/eslint-plugin": "^1.6.16",
     "eslint": "^9.39.4",
@@ -65,9 +66,10 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "chokidar": "^3.6.0",
+    "chokidar": "^5.0.0",
     "p-map": "^7.0.4",
     "picocolors": "^1.1.1",
+    "picomatch": "^4.0.3",
     "tinyglobby": "^0.2.16"
   },
   "compatiblePackages": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,17 @@ importers:
   .:
     dependencies:
       chokidar:
-        specifier: ^3.6.0
-        version: 3.6.0
+        specifier: ^5.0.0
+        version: 5.0.0
       p-map:
         specifier: ^7.0.4
         version: 7.0.4
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      picomatch:
+        specifier: ^4.0.3
+        version: 4.0.4
       tinyglobby:
         specifier: ^0.2.16
         version: 0.2.16
@@ -39,6 +42,9 @@ importers:
       '@types/node':
         specifier: ^22.19.17
         version: 22.19.17
+      '@types/picomatch':
+        specifier: ^4.0.2
+        version: 4.0.3
       '@types/throttle-debounce':
         specifier: ^5.0.2
         version: 5.0.2
@@ -579,6 +585,9 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/picomatch@4.0.3':
+    resolution: {integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==}
+
   '@types/throttle-debounce@5.0.2':
     resolution: {integrity: sha512-pDzSNulqooSKvSNcksnV72nk8p7gRqN8As71Sp28nov1IgmPKWbOEIwAWvBME5pPTtaXJAvG3O4oc76HlQ4kqQ==}
 
@@ -752,10 +761,6 @@ packages:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -780,10 +785,6 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
-
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
 
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
@@ -818,9 +819,9 @@ packages:
   chardet@2.1.0:
     resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
 
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1087,10 +1088,6 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1284,10 +1281,6 @@ packages:
       encoding:
         optional: true
 
-  normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -1402,9 +1395,9 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2213,6 +2206,8 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/picomatch@4.0.3': {}
+
   '@types/throttle-debounce@5.0.2': {}
 
   '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.0))(typescript@6.0.3)':
@@ -2433,11 +2428,6 @@ snapshots:
 
   ansis@4.2.0: {}
 
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -2459,8 +2449,6 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
-
-  binary-extensions@2.3.0: {}
 
   birpc@4.0.0: {}
 
@@ -2490,17 +2478,9 @@ snapshots:
 
   chardet@2.1.0: {}
 
-  chokidar@3.6.0:
+  chokidar@5.0.0:
     dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
+      readdirp: 5.0.0
 
   color-convert@2.0.1:
     dependencies:
@@ -2775,10 +2755,6 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -2922,8 +2898,6 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  normalize-path@3.0.0: {}
-
   obug@2.1.1: {}
 
   optionator@0.9.4:
@@ -3014,9 +2988,7 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.1
+  readdirp@5.0.0: {}
 
   resolve-from@4.0.0: {}
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,4 @@
-import type { WatchOptions } from 'chokidar'
+import type { ChokidarOptions } from 'chokidar'
 
 type MaybePromise<T> = T | Promise<T>
 type WithRequiredSingleKey<T, K extends keyof T> = {
@@ -138,7 +138,7 @@ export type ViteStaticCopyOptions = {
     /**
      * Watch options
      */
-    options?: WatchOptions
+    options?: ChokidarOptions
     /**
      * Reloads page on file change when true
      * @default false
@@ -161,7 +161,7 @@ export type ResolvedViteStaticCopyOptions = {
   targets: Target[]
   silent: boolean
   watch: {
-    options: WatchOptions
+    options: ChokidarOptions
     reloadPageOnChange: boolean
   }
   hook: string

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -8,7 +8,9 @@ import {
   formatConsole,
 } from './utils'
 import { debounce } from 'throttle-debounce'
+import type { FSWatcher, Matcher } from 'chokidar'
 import chokidar from 'chokidar'
+import picomatch from 'picomatch'
 import pc from 'picocolors'
 import path from 'node:path'
 
@@ -27,7 +29,7 @@ export const servePlugin = ({
   environment,
 }: ResolvedViteStaticCopyOptions): Plugin => {
   let config: ResolvedConfig
-  let watcher: chokidar.FSWatcher
+  let watcher: FSWatcher
   const fileMap: FileMap = new Map()
 
   const collectFileMap = async () => {
@@ -60,13 +62,50 @@ export const servePlugin = ({
         ws.send({ type: 'full-reload', path: '*' })
       }
 
-      // cannot use server.watcher since disableGlobbing is true
+      const { watchSpecs, srcMatchers, globalDepth } =
+        resolveWatchSources(targets)
+
+      // chokidar invokes `ignored` with absolute paths, and stats is only
+      // defined once the entry has been stat'd. For files, reject those that
+      // don't match any src pattern. For directories, prune subtrees that no
+      // watch spec can descend into — otherwise a shallow pattern like
+      // `foo.*` (base='.', depth=0) would still cause chokidar to walk the
+      // entire project since the global `depth` option falls back to
+      // unlimited when any other pattern needs it. Paths we can't classify
+      // (stats undefined, symlinks, …) pass through so chokidar handles them.
+      const srcMatcher: Matcher = (p, stats) => {
+        if (!stats) return false
+        const relative = path.isAbsolute(p) ? path.relative(config.root, p) : p
+        const normalized = relative.split(path.sep).join('/')
+        if (stats.isDirectory()) {
+          return !watchSpecs.some((spec) => {
+            const depth = depthFromBase(spec.base, normalized)
+            if (depth < 0) return false
+            return spec.depth === undefined || depth <= spec.depth
+          })
+        }
+        if (stats.isFile()) {
+          return !srcMatchers.some((m) => m(normalized))
+        }
+        return false
+      }
+
+      const userIgnored = watch.options.ignored
+      const userIgnoredArr: Matcher[] = Array.isArray(userIgnored)
+        ? userIgnored
+        : userIgnored != null
+          ? [userIgnored]
+          : []
+
+      // cannot use server.watcher since it filters non-code files
       watcher = chokidar.watch(
-        targets.flatMap((target) => target.src),
+        watchSpecs.map((s) => s.base),
         {
           cwd: config.root,
           ignoreInitial: true,
+          ...(globalDepth !== undefined ? { depth: globalDepth } : {}),
           ...watch.options,
+          ignored: [...userIgnoredArr, srcMatcher],
         },
       )
       watcher.on('add', async (path) => {
@@ -147,6 +186,81 @@ export const servePlugin = ({
       await watcher.close()
     },
   }
+}
+
+type WatchSpec = {
+  // Forward-slash base path (relative to cwd unless the user passed an
+  // absolute path).
+  base: string
+  // Max directory descent chokidar should make under this base. `undefined`
+  // means unlimited (literal base that may point at a directory, or a pattern
+  // containing `**`).
+  depth: number | undefined
+}
+
+// chokidar v4+ dropped glob support, so resolve each src pattern to a base
+// directory to watch and a per-pattern matcher used to filter emitted events.
+// Patterns are normalized to forward slashes so matching lines up with the
+// normalized event paths regardless of the platform separator. Depth is
+// tracked per base so a shallow glob like `foo.*` (base='.', depth=0) doesn't
+// force chokidar to walk the whole project just because a sibling pattern
+// elsewhere needs unlimited depth.
+const resolveWatchSources = (
+  targets: ResolvedViteStaticCopyOptions['targets'],
+) => {
+  const watchSpecs: WatchSpec[] = []
+  const srcMatchers: ((p: string) => boolean)[] = []
+  const upsertSpec = (base: string): WatchSpec => {
+    let spec = watchSpecs.find((s) => s.base === base)
+    if (!spec) {
+      spec = { base, depth: 0 }
+      watchSpecs.push(spec)
+    }
+    return spec
+  }
+  for (const target of targets) {
+    const patterns = Array.isArray(target.src) ? target.src : [target.src]
+    for (const rawPattern of patterns) {
+      const pattern = rawPattern.split(path.sep).join('/')
+      const scanned = picomatch.scan(pattern)
+      if (scanned.isGlob) {
+        const spec = upsertSpec(scanned.base || '.')
+        srcMatchers.push(picomatch(pattern, { dot: true }))
+        if (spec.depth !== undefined) {
+          if (scanned.glob.includes('**')) {
+            spec.depth = undefined
+          } else {
+            spec.depth = Math.max(
+              spec.depth,
+              scanned.glob.split('/').length - 1,
+            )
+          }
+        }
+      } else {
+        const spec = upsertSpec(pattern)
+        spec.depth = undefined
+        srcMatchers.push((p) => p === pattern || p.startsWith(`${pattern}/`))
+      }
+    }
+  }
+  // chokidar's `depth` is global; set it to the loosest per-spec bound so the
+  // per-base pruning in the `ignored` matcher can handle the stricter cases.
+  const globalDepth = watchSpecs.some((s) => s.depth === undefined)
+    ? undefined
+    : Math.max(0, ...watchSpecs.map((s) => s.depth as number))
+  return { watchSpecs, srcMatchers, globalDepth }
+}
+
+// How many directory levels deep `path` sits within `base`. Returns -1 when
+// `path` is not under `base` at all.
+const depthFromBase = (base: string, path: string): number => {
+  if (base === '.') {
+    if (path === '' || path === '.') return 0
+    return path.split('/').length
+  }
+  if (path === base) return 0
+  if (!path.startsWith(`${base}/`)) return -1
+  return path.slice(base.length + 1).split('/').length
 }
 
 const findMiddlewareIndex = (

--- a/test/watcher.test.ts
+++ b/test/watcher.test.ts
@@ -1,0 +1,164 @@
+import { describe, test, beforeAll, afterAll, expect } from 'vitest'
+import { createServer } from 'vite'
+import type { ViteDevServer } from 'vite'
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import type { AddressInfo } from 'node:net'
+import { viteStaticCopy } from '../src'
+
+const fetchFrom = async (server: ViteDevServer, urlPath: string) => {
+  const port = (server.httpServer!.address() as AddressInfo).port
+  const res = await fetch(`http://localhost:${port}${urlPath}`)
+  return {
+    status: res.status,
+    body: res.status === 200 ? await res.text() : null,
+  }
+}
+
+const waitFor = async <T>(
+  fn: () => Promise<T>,
+  predicate: (v: T) => boolean,
+  timeoutMs = 5000,
+  intervalMs = 50,
+): Promise<T> => {
+  const deadline = Date.now() + timeoutMs
+  while (true) {
+    const last = await fn()
+    if (predicate(last)) return last
+    if (Date.now() >= deadline) {
+      throw new Error('waitFor timed out')
+    }
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+}
+
+describe('dev-server watcher', () => {
+  let root: string
+  let server: ViteDevServer
+
+  beforeAll(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'vps-watch-'))
+    await mkdir(path.join(root, 'assets'), { recursive: true })
+    await writeFile(path.join(root, 'assets', 'initial.txt'), 'initial')
+    await writeFile(path.join(root, 'direct.txt'), 'direct')
+
+    server = await createServer({
+      root,
+      logLevel: 'silent',
+      appType: 'custom',
+      plugins: [
+        viteStaticCopy({
+          targets: [
+            { src: 'assets/**/*.txt', dest: 'copied' },
+            { src: 'direct.txt', dest: 'copied' },
+          ],
+        }),
+      ],
+    })
+    await server.listen()
+    // give chokidar's initial scan time to finish so subsequent writes
+    // are reported as real `add` events rather than initial-scan entries
+    await new Promise((r) => setTimeout(r, 300))
+  })
+
+  afterAll(async () => {
+    await server.close()
+    await rm(root, { recursive: true, force: true })
+  })
+
+  test('serves glob-matched file that existed at startup', async () => {
+    const { status, body } = await fetchFrom(
+      server,
+      '/copied/assets/initial.txt',
+    )
+    expect(status).toBe(200)
+    expect(body).toBe('initial')
+  })
+
+  test('serves literal-path file that existed at startup', async () => {
+    const { status, body } = await fetchFrom(server, '/copied/direct.txt')
+    expect(status).toBe(200)
+    expect(body).toBe('direct')
+  })
+
+  test('detects new file added under a glob source', async () => {
+    await writeFile(path.join(root, 'assets', 'new.txt'), 'new-content')
+    const result = await waitFor(
+      () => fetchFrom(server, '/copied/assets/new.txt'),
+      (r) => r.status === 200,
+    )
+    expect(result.body).toBe('new-content')
+  })
+
+  test('detects new file in a subdirectory matched by **', async () => {
+    await mkdir(path.join(root, 'assets', 'nested'), { recursive: true })
+    await writeFile(
+      path.join(root, 'assets', 'nested', 'deep.txt'),
+      'deep-content',
+    )
+    const result = await waitFor(
+      () => fetchFrom(server, '/copied/assets/nested/deep.txt'),
+      (r) => r.status === 200,
+    )
+    expect(result.body).toBe('deep-content')
+  })
+
+  test('ignores new file that does not match any glob', async () => {
+    await writeFile(path.join(root, 'assets', 'ignored.md'), 'ignored')
+    // give the watcher time to observe the write and (correctly) skip it
+    await new Promise((r) => setTimeout(r, 500))
+    const { status } = await fetchFrom(server, '/copied/assets/ignored.md')
+    expect(status).toBe(404)
+  })
+})
+
+describe('dev-server watcher — shallow-glob only config', () => {
+  // All-shallow config exercises the depth-bounded watcher path: no `**`,
+  // no literal paths that could be a directory, so chokidar should be run
+  // with a bounded `depth` rather than recursing unbounded.
+  let root: string
+  let server: ViteDevServer
+
+  beforeAll(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'vps-watch-shallow-'))
+    await mkdir(path.join(root, 'shallow'), { recursive: true })
+    await writeFile(path.join(root, 'shallow', 'initial.txt'), 'initial')
+
+    server = await createServer({
+      root,
+      logLevel: 'silent',
+      appType: 'custom',
+      plugins: [
+        viteStaticCopy({
+          targets: [{ src: 'shallow/*.txt', dest: 'copied' }],
+        }),
+      ],
+    })
+    await server.listen()
+    await new Promise((r) => setTimeout(r, 300))
+  })
+
+  afterAll(async () => {
+    await server.close()
+    await rm(root, { recursive: true, force: true })
+  })
+
+  test('serves files directly in the base directory', async () => {
+    const { status, body } = await fetchFrom(
+      server,
+      '/copied/shallow/initial.txt',
+    )
+    expect(status).toBe(200)
+    expect(body).toBe('initial')
+  })
+
+  test('detects a new file directly in the base directory', async () => {
+    await writeFile(path.join(root, 'shallow', 'new.txt'), 'new-shallow')
+    const result = await waitFor(
+      () => fetchFrom(server, '/copied/shallow/new.txt'),
+      (r) => r.status === 200,
+    )
+    expect(result.body).toBe('new-shallow')
+  })
+})


### PR DESCRIPTION
chokidar v5 drops the dependency count from 13 packages to 1 (readdirp) and cuts bundle size roughly in half (~150kb → ~80kb).

v5 requires node >=20.19, which is less strict than (^22 || >= 24), the current engines setting in this package.

We have to add picomatch as a direct dep since globbing is no longer built-in to chokidar, but picomatch is anyway a dep of tinyglobby, and therefore de-dupes.

Some notes:
- Glob support was removed in chokidar v4. We now resolve each `src` pattern with picomatch: watch the non-glob base directories and pass an `ignored` matcher that filters emitted events against the original patterns.
- chokidar invokes `ignored` with absolute paths (and with `stats` undefined until the entry has been stat'd). Patterns are relative, so the matcher converts to cwd-relative before matching, and only filters known-file entries — otherwise the watched directory itself gets ignored and chokidar never descends into it.
- The exported option type is renamed: `watch.options` is now `ChokidarOptions` (was `WatchOptions`). Options removed upstream (`disableGlobbing`, `useFsEvents`, …) are no longer accepted.

To be safe, and show the migration works, we add a dev-server watcher test covering both glob and literal `src` entries, including new-file detection under `**`. The same test also passes unchanged against `main` (chokidar v3).